### PR TITLE
🔧 Updates docker-entrypoint.sh file 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,16 @@
+## Spill specific information
+The below is based on the Heroku tutorial which can be found [here](https://devcenter.heroku.com/articles/container-registry-and-runtime#cli)
+To deploy this image to Heroku the following steps should be followed:
+1. Build the image: `docker buildx build --platform linux/amd64 -t <some-tag> .` (This ensures that the image is built on the correct architecture. Heroku doesn't like images built to the M1 Mac specificaiton)
+2. Tag the image: `docker tag <some-tag> registry.heroku.com/spill-supertokens/web`
+3. Push the image to the Heroku registry: `docker push registry.heroku.com/spill-supertokens/web`
+4. Login to the Heroku cli (download it if you don't already have it)
+5. Release the image: `heroku container:release web -a spill-supertokens-staging` 
+6. Check that its running: `heroku open -a spill-supertokens-staging`
+
+### WHy did we fork this repo?
+We have also made some changes to the `docker-entrypoint.sh` specifically around the ownership of file directories by the supertokens user. The command `chown -R supertokens:supertokens /usr/lib/supertokens/` on line 35 causes the container to crash. Our current workaround is to just comment out the line as done in this [issue](https://github.com/supertokens/supertokens-core/issues/354) raised last year 
+
 ## Quickstart
 ```bash
 # This will start with an in memory database.

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -31,12 +31,13 @@ if [ "${1}" = 'dev' -o "${1}" = "production" -o "${1:0:2}" = "--" ]; then
     fi
 fi
 
+SUPERTOKENS_PORT=$PORT
 CONFIG_FILE=/usr/lib/supertokens/config.yaml
 CONFIG_MD5SUM="$(md5sum /usr/lib/supertokens/config.yaml | awk '{ print $1 }')"
 
 # if files have been shared using shared volumes, make sure the ownership of the
 # /usr/lib/supertokens files still remains with supertokens user
-chown -R supertokens:supertokens /usr/lib/supertokens/
+# chown -R supertokens:supertokens /usr/lib/supertokens/
 
 if [ "$CONFIG_HASH" = "$CONFIG_MD5SUM" ]
 then
@@ -192,8 +193,8 @@ then
             touch $INFO_LOG_PATH
         fi
         # make sure supertokens user has write permission on the file
-        chown supertokens:supertokens $INFO_LOG_PATH
-        chmod +w $INFO_LOG_PATH
+        # chown supertokens:supertokens $INFO_LOG_PATH
+        # chmod +w $INFO_LOG_PATH
         echo "info_log_path: $INFO_LOG_PATH" >> $CONFIG_FILE
     else
         echo "info_log_path: null" >> $CONFIG_FILE
@@ -207,8 +208,8 @@ then
             touch $ERROR_LOG_PATH
         fi
         # make sure supertokens user has write permission on the file
-        chown supertokens:supertokens $ERROR_LOG_PATH
-        chmod +w $ERROR_LOG_PATH
+        # chown supertokens:supertokens $ERROR_LOG_PATH
+        # chmod +w $ERROR_LOG_PATH
         echo "error_log_path: $ERROR_LOG_PATH" >> $CONFIG_FILE
     else
         echo "error_log_path: null" >> $CONFIG_FILE
@@ -318,9 +319,11 @@ then
     set -- "$@" --foreground
 fi
 
+# Commented out because heroku does not allow running as root and we can't set the supertokens user
 # If container is started as root user, restart as dedicated supertokens user
-if [ "$(id -u)" = "0" ] && [ "$1" = 'supertokens' ]; then
-    exec gosu supertokens "$@"
-else
-    exec "$@"
-fi
+# if [ "$(id -u)" = "0" ] && [ "$1" = 'supertokens' ]; then
+#     exec gosu supertokens "$@"
+# else
+#     exec "$@"
+# fi
+exec "$@"


### PR DESCRIPTION
## Overview

Changing the `docker-entrypoint.sh` script to remove references to `chown` command as this causes the container in heroku to crash at runtime. This is outlined in an issue with the mySql docker setup for supertokens https://github.com/supertokens/supertokens-core/issues/354. 

We're also going with forking the repository as this issue prevents us from running the image directly on heroku and we want to be able to pin our version of supertokens core to avoid unstable releases and breaking changes

## Testing

Tested on Heroku and running

## Risk

No risk as nothing is live